### PR TITLE
ID-input-validation-no-input

### DIFF
--- a/frontend-website/src/components/inputField.vue
+++ b/frontend-website/src/components/inputField.vue
@@ -12,10 +12,15 @@
       />
       <!-- nur wenn this.error true ist wird das label gezeigt -->
       <label
-        v-if="this.error"
+        v-if="this.error === true"
         v-bind:for="inputID"
         class="error-text input-field-error-msg"
       >Die Nummer konnte nicht gefunden werden</label>
+      <label
+        v-if="this.error === 'noInput'"
+        v-bind:for="inputID"
+        class="error-text input-field-error-msg"
+      >Bitte geben Sie eine Nummer ein</label>
       <div class="button-wrapper">
         <input
           class="button-submit button-text"

--- a/frontend-website/src/views/Home.vue
+++ b/frontend-website/src/views/Home.vue
@@ -32,6 +32,8 @@ export default {
 
       if (this.paintingIDs.includes(input)) {
         open("/waiting", "_self");
+      } else if (document.querySelector(".input-field").value === "") {
+        this.transponderNotFound = "noInput"
       } else {
         this.transponderNotFound = true;
       }


### PR DESCRIPTION
Wenn keine Nummer eingegeben wurde, wird der Wert von <transponderNotFound> auf "noInput" gesetzt. Dadurch wird ein anderes Label angezeigt mit der entsprechenden Meldung