### PR TITLE
bug fixing; der fab springt nicht mehr nach rechts

### DIFF
--- a/frontend-website/src/assets/scss/010-variables.scss
+++ b/frontend-website/src/assets/scss/010-variables.scss
@@ -22,7 +22,7 @@ $abstand-XXXL: 1rem * 5; // 80
 
 $app-bar-height: 1rem * 3.375; // 54
 $icon-wrapper-width: 1rem * 3; // 48
-$fab-size: 1rem * 3.5;
+$fab-size: 1rem * 3.5; // 56
 
 //* Font Sizes *//
 

--- a/frontend-website/src/assets/scss/020-base.scss
+++ b/frontend-website/src/assets/scss/020-base.scss
@@ -18,3 +18,8 @@ input {
 input:active {
   background-color: transparent;
 }
+
+body {
+  width: 100vw;
+  height: 100vh;
+}

--- a/frontend-website/src/components/accordion.vue
+++ b/frontend-website/src/components/accordion.vue
@@ -28,6 +28,7 @@
     </div>
     <slider
       audio-slider
+      class="slider"
       v-if="current"
       v-bind:value="currentValue"
       v-bind:min="0"

--- a/frontend-website/src/components/fab.vue
+++ b/frontend-website/src/components/fab.vue
@@ -28,8 +28,6 @@ export default {
   align-items: center;
   justify-content: center;
   border-radius: 100%;
-  right: 0;
-  bottom: 0;
   box-shadow: 0px 14px 14px rgba(0, 0, 0, 0.237602),
     0px 0px 14px rgba(0, 0, 0, 0.12);
 }

--- a/frontend-website/src/views/Painting.vue
+++ b/frontend-website/src/views/Painting.vue
@@ -144,8 +144,29 @@ export default {
     });
 
     this.handleMQTTConnection();
+    this.setPositionOfFab();
   },
   methods: {
+    /**
+     * Problem: Wenn der fab zur rechten und unteren Seite ein margin hat, schiebt er
+     * sich im Laufe des Abspielens der Audiodatei hin und her
+     * (manchmal wird der Screen größer)
+     * Deswegen werden in dieser Methode die Maße des Screens ermittelt und dem fab ein
+     * linkes und rechtes margin gegeben
+     * Am Ende soll der fab in der unteren rechten Ecke des Screens zu finden sein
+     */
+    setPositionOfFab() {
+      var fab = this.$el.querySelector("[js-fab]");
+
+      var fabSize = 56;
+      var margin = 16;
+
+      const marginLeft = screen.width - fabSize - margin;
+      const marginTop = screen.height - fabSize - margin;
+
+      fab.style.marginLeft = marginLeft + "px";
+      fab.style.marginTop = marginTop + "px";
+    },
     setCurrent(id) {
       /**
        * setCurrent ist dazu da eine Info mit der übergebenen id auszuwählen
@@ -327,11 +348,14 @@ export default {
         // Eine URL mit der jeweiligen ID wird geöffnet
         //this.$router.push({ path: `user/${_this.topic}/painting/${message.payloadString}`});
         let userid = this_component.topic;
-        this_component.$router.push({name: 'painting', params: {userid: userid, id: message.payloadString}})
+        this_component.$router.push({
+          name: "painting",
+          params: { userid: userid, id: message.payloadString }
+        });
       }
     }
   },
-  beforeRouteUpdate (to, from, next) {
+  beforeRouteUpdate(to, from, next) {
     if (to.path !== from.path) {
       let paintings = require("../data/database.js").paintings;
       let painting = this.painting;
@@ -367,7 +391,7 @@ export default {
 
   .fab {
     position: fixed;
-    margin: 0 $abstand-M $abstand-M 0;
+    // margin: 0 $abstand-M $abstand-M 0;
   }
 
   img {


### PR DESCRIPTION
Wie schon im Commit gesagt, der fab springt nicht mehr nach rechts. Es gibt bestimmt schönere Wege. Am Ende der Audiospur wird der Bildschirm etwas breiter, was aber NUR sichtbar ist wenn man zu exakt diesem Zeitpunkt nach rechts scrollt (ca. 0.5 Sekunden) und das ist NUR bei Google Chrome der Fall. Ich hab dem fab jetzt mithilfe der Methode setPositionOfFab ein linkes und oberes margin gegeben